### PR TITLE
feat: support external login service

### DIFF
--- a/EndUID/end_bind/__init__.py
+++ b/EndUID/end_bind/__init__.py
@@ -142,9 +142,11 @@ async def send_end_phone_login_msg(bot: Bot, ev: Event):
     if not EndConfig.get_config("EndLoginUrl").data:
         return await send_end_scan_login_msg(bot, ev)
 
-    from .web_login import phone_web_login_entry
+    from .web_login import phone_web_login_entry, phone_web_login_external_entry
 
-    return await phone_web_login_entry(bot, ev)
+    if EndConfig.get_config("EndLoginUrlSelf").data:
+        return await phone_web_login_entry(bot, ev)
+    return await phone_web_login_external_entry(bot, ev)
 
 
 async def _persist_login_cred(

--- a/EndUID/end_bind/web_login.py
+++ b/EndUID/end_bind/web_login.py
@@ -2,31 +2,32 @@
 
 from __future__ import annotations
 
-import time
-import base64
 import asyncio
+import base64
+import re
 import secrets
+import time
 from io import BytesIO
 from pathlib import Path
 
+import httpx
 from async_timeout import timeout
-from jinja2 import Environment, FileSystemLoader
-from pydantic import BaseModel
-from starlette.responses import HTMLResponse
-
 from gsuid_core.bot import Bot
 from gsuid_core.config import core_config
 from gsuid_core.logger import logger
 from gsuid_core.models import Event
 from gsuid_core.segment import MessageSegment
-from gsuid_core.web_app import app
 from gsuid_core.utils.cookie_manager.qrlogin import get_qrcode_base64
+from gsuid_core.web_app import app
+from jinja2 import Environment, FileSystemLoader
+from pydantic import BaseModel
+from starlette.responses import HTMLResponse
 
 from ..end_config import EndConfig
 from ..end_wiki.fetch import pick_random_background
-from ..utils.image import pic_download_from_url
 from ..utils.api.requests import end_api
 from ..utils.cache import TimedCache
+from ..utils.image import pic_download_from_url
 from ..utils.path import MAIN_PATH, TEMP_PATH, WIKI_IMG_CACHE
 
 GAME_TITLE = "「终末地」"
@@ -167,6 +168,116 @@ async def phone_web_login_entry(bot: Bot, ev: Event):
         return
     except Exception as e:
         logger.exception(f"[ENDUID·网页登录] 异常: {e}")
+
+
+async def phone_web_login_external_entry(bot: Bot, ev: Event):
+    """使用外置服务完成手机号验证，凭据验证与入库仍由 EndUID 负责。"""
+    at_sender = True if ev.group_id else False
+    url = await get_url()
+    auth = {"bot_id": ev.bot_id, "user_id": ev.user_id}
+    shared_secret = str(
+        EndConfig.get_config("EndLoginSharedSecret").data or ""
+    ).strip()
+    if len(shared_secret) < 32:
+        return await bot.send(
+            (" " if at_sender else "")
+            + f"{GAME_TITLE} 请配置至少 32 位的终末地外置登录共享密钥",
+            at_sender=at_sender,
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.post(
+                f"{url}/end/token",
+                json=auth,
+                headers={"X-EndUID-Secret": shared_secret},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise TypeError("外置服务返回了无效响应")
+            user_token = str(payload.get("token") or "")
+            if not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", user_token):
+                raise ValueError("外置服务返回了无效会话")
+            poll_token = str(payload.get("poll_token") or "")
+            if not re.fullmatch(r"[A-Za-z0-9_-]{32,128}", poll_token):
+                raise ValueError("外置服务返回了无效轮询凭据")
+
+            await send_login(bot, ev, f"{url}/end/i/{user_token}")
+
+            failures = 0
+            hg_token = ""
+            try:
+                async with timeout(180):
+                    while True:
+                        try:
+                            result = await client.post(
+                                f"{url}/end/get",
+                                json={
+                                    "token": user_token,
+                                    "poll_token": poll_token,
+                                },
+                            )
+                            result.raise_for_status()
+                            data = result.json()
+                            if not isinstance(data, dict):
+                                raise TypeError("外置服务返回了无效响应")
+                            failures = 0
+                        except (httpx.HTTPError, TypeError, ValueError) as exc:
+                            failures += 1
+                            logger.warning(
+                                f"[ENDUID·外置登录] 轮询失败 ({failures}/3): {exc}"
+                            )
+                            if failures >= 3:
+                                return await bot.send(
+                                    (" " if at_sender else "")
+                                    + f"{GAME_TITLE} 外置登录服务请求失败，请稍后重试",
+                                    at_sender=at_sender,
+                                )
+                            await asyncio.sleep(3)
+                            continue
+
+                        if not data.get("done"):
+                            await asyncio.sleep(1)
+                            continue
+                        if not data.get("success"):
+                            return await bot.send(
+                                (" " if at_sender else "")
+                                + f"{GAME_TITLE} {data.get('msg') or '登录失败'}",
+                                at_sender=at_sender,
+                            )
+                        if (
+                            str(data.get("user_id") or "") != str(ev.user_id)
+                            or str(data.get("bot_id") or "") != str(ev.bot_id)
+                        ):
+                            logger.error("[ENDUID·外置登录] 会话身份不匹配，拒绝入库")
+                            return await bot.send(
+                                (" " if at_sender else "")
+                                + f"{GAME_TITLE} 登录会话身份校验失败",
+                                at_sender=at_sender,
+                            )
+                        hg_token = str(data.get("hg_token") or "")
+                        if not hg_token or len(hg_token) > 4096:
+                            return await bot.send(
+                                (" " if at_sender else "")
+                                + f"{GAME_TITLE} 外置服务未返回有效 Token",
+                                at_sender=at_sender,
+                            )
+                        break
+            except asyncio.TimeoutError:
+                return await bot.send(
+                    (" " if at_sender else "") + f"{GAME_TITLE} 登录超时!",
+                    at_sender=at_sender,
+                )
+            from . import check_token
+
+            return await check_token(bot, ev, hg_token)
+    except (httpx.HTTPError, TypeError, ValueError) as exc:
+        logger.error(f"[ENDUID·外置登录] 创建会话失败: {exc}")
+        return await bot.send(
+            (" " if at_sender else "") + f"{GAME_TITLE} 外置登录服务请求失败，请稍后重试",
+            at_sender=at_sender,
+        )
 
 
 async def _push_text(state: dict, text: str):

--- a/EndUID/end_config/config_default.py
+++ b/EndUID/end_config/config_default.py
@@ -46,8 +46,20 @@ CONFIG_DEFAULT: Dict[str, GSC] = {
     # ==================== 登录配置 ====================
     "EndLoginUrl": GsStrConfig(
         "终末地登录url",
-        "EndUID 登录/抽卡网页的对外地址（域名/穿透/反代到本 core）。留空则用 core 的 HOST:PORT，"
-        "群聊远端用户需能访问到该地址，建议反代后在此填写。",
+        "EndUID 登录/抽卡网页的对外地址。使用本体登录时填写反代到 core 的地址；"
+        "使用外置登录时填写外置服务地址。留空则使用森空岛扫码登录。",
+        "",
+        secret=True,
+    ),
+    "EndLoginUrlSelf": GsBoolConfig(
+        "强制【终末地登录url】为自己的域名",
+        "外置登录服务请关闭；自己穿透或反代本 core 请打开。为兼容旧配置默认打开。",
+        True,
+    ),
+    "EndLoginSharedSecret": GsStrConfig(
+        "终末地外置登录共享密钥",
+        "仅在使用外置登录时填写，必须与外置服务的 END_SHARED_SECRET 完全一致。"
+        "建议使用至少32位随机字符串。",
         "",
         secret=True,
     ),

--- a/EndUID/end_gacha/web_view.py
+++ b/EndUID/end_gacha/web_view.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
+import json
 import secrets
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
 
-from starlette.responses import FileResponse, HTMLResponse, JSONResponse
-
+import httpx
+from gsuid_core.logger import logger
 from gsuid_core.models import Event
 from gsuid_core.web_app import app
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse
 
+from ..end_bind.web_login import get_url
 from ..end_config import PREFIX
 from ..end_config.config_default import EndConfig
 from ..utils.cache import TimedCache
 from ..utils.path import MAIN_PATH, PLAYER_PATH
 from ..utils.player_store import player_json_exists
 from ..utils.util import hide_uid
-from ..end_bind.web_login import get_url
 from .draw_gachalogs import build_gacha_pools
 
 GACHA_WEB_TTL = 600  # 10 分钟
@@ -66,11 +68,58 @@ async def make_gacha_web_url(
         "now": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }
 
-    token = secrets.token_urlsafe(16)
-    _token_cache.set(token, web_payload)
-
     base = (await get_url()).rstrip("/")
+    token = secrets.token_urlsafe(16)
+    configured_url = str(EndConfig.get_config("EndLoginUrl").data or "").strip()
+    if EndConfig.get_config("EndLoginUrlSelf").data or not configured_url:
+        _token_cache.set(token, web_payload)
+    else:
+        ok = await _push_gacha_to_external(base, token, web_payload)
+        if not ok:
+            return None, "外置抽卡页面上传失败，请稍后重试"
     return f"{base}/end/gacha/{token}", "ok"
+
+
+async def _push_gacha_to_external(base: str, token: str, payload: dict) -> bool:
+    """上传受限 JSON 摘要；外置服务不接收可执行 HTML。"""
+    shared_secret = str(
+        EndConfig.get_config("EndLoginSharedSecret").data or ""
+    ).strip()
+    if len(shared_secret) < 32:
+        logger.warning("[ENDUID·抽卡网页] 外置登录共享密钥未配置或不足 32 位")
+        return False
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{base}/end/gacha/data/{token}",
+                content=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-EndUID-Secret": shared_secret,
+                },
+            )
+        if response.status_code != 200:
+            logger.warning(
+                f"[ENDUID·抽卡网页] 外置上传失败: "
+                f"HTTP {response.status_code} {response.text[:160]}"
+            )
+            return False
+        result = response.json()
+        if not isinstance(result, dict):
+            raise TypeError("外置服务返回了无效响应")
+        if not result.get("success"):
+            logger.warning(f"[ENDUID·抽卡网页] 外置上传被拒绝: {result}")
+            return False
+        logger.info(
+            f"[ENDUID·抽卡网页] 已上传外置摘要 token={token} size={len(body)}"
+        )
+        return True
+    except (httpx.HTTPError, TypeError, ValueError) as exc:
+        logger.warning(f"[ENDUID·抽卡网页] 外置上传异常: {exc}")
+        return False
 
 
 _NOT_FOUND_HTML = """<!DOCTYPE html><html lang=zh-CN><meta charset=utf-8>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ git clone https://github.com/Loping151/EndUID
 
 支持森空岛扫码登录。链接登陆需自行配置网络。
 
+### 外置网页登录
+
+可使用支持 EndUID 协议的外置登录服务（例如新版 `ww-login`）：
+
+1. `EndLoginUrl` 填写外置服务的公网 HTTPS 地址；
+2. 关闭 `EndLoginUrlSelf`；
+3. 生成至少 32 位随机字符串，同时写入 EndUID 的 `EndLoginSharedSecret` 和
+   外置服务环境变量 `END_SHARED_SECRET`；
+4. 反向代理放行 `/end/*`。
+
+手机号验证由外置服务完成，Token 校验、Cred 换取、绑定入库和后续同步仍由
+EndUID 本体完成。开启 `EndGachaWebPage` 后，外置模式也会把抽卡摘要上传到同一
+服务，链接有效期为 10 分钟。若使用反代本 core 的旧部署方式，请保持
+`EndLoginUrlSelf` 开启。
+
 催更/反馈/Bug/建议：群号 885617919（注意入群问题的答案仓库是 [XutheringWavesUID](https://github.com/Loping151/XutheringWavesUID)），共用一个，不想再建群了。Issue亦会看。如果森空岛出了新的可查询内容，并且你希望通过EndUID查看，请告诉我。
 
 ## 丨其他


### PR DESCRIPTION
## 变更内容

- 为 EndUID 增加可选的外置手机号登录模式，并保留原有本体网页登录和扫码登录行为
- 使用服务间共享密钥创建会话，公开页面 token 与私有轮询 token 分离
- 外置登录完成后仍由 EndUID 本体校验 Token、换取 Cred、绑定入库及触发后续同步
- 外置模式下将受限的抽卡 JSON 摘要上传至服务端，不上传可执行 HTML
- 增加配置项与部署文档

## 原因与影响

EndUID 当前只支持由 core 自身承载网页。此变更让部署者可以把登录与抽卡展示交给独立的 ww-login 服务，同时把凭据持久化和用户身份校验继续留在 EndUID 内部。旧配置默认启用 `EndLoginUrlSelf`，不会改变既有部署行为。

## 验证

- EndUID 全量 Python 编译检查通过
- 配套 ww-login 协议测试 24 项全部通过
- review agent 完成三轮安全与并发审查，无阻断问题
